### PR TITLE
Update CI workflow trigger branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Basic Android CI
 
 on:
     push:
-        branches: [ main, master ]
+        branches: [ main, develop ]
     pull_request:
-        branches: [ main, master ]
+        branches: [ main, develop ]
 
 jobs:
     code_quality_checks:


### PR DESCRIPTION
The GitHub Actions CI workflow has been updated to trigger on pushes and pull requests to the `develop` branch in addition to the `main` branch. The `master` branch has been removed from the trigger conditions.